### PR TITLE
Change processors to return stats upon joining

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -356,9 +356,9 @@ mod tests {
         let cfg = Config::from_string(yml).unwrap();
         let workers = cfg.workers();
 
-        assert_ne!(workers.num_processors(), DEFAULT_NUM_PROCESSORS);
-        assert_ne!(workers.num_feeders(), DEFAULT_NUM_FEEDERS);
-        assert_ne!(workers.num_loaders(), DEFAULT_NUM_LOADERS);
+        assert_ne!(workers.num_processors(), 0);
+        assert_ne!(workers.num_feeders(), 0);
+        assert_ne!(workers.num_loaders(), 0);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ fn main() {
         &feed_recvr,
         &load_sendr,
         cfg.yara_rule_dir(),
-        cfg.workers().num_processors()
+        cfg.workers().num_processors() as usize
     );
 
     let l_handles = database::start_loaders(&load_recvr, db_loader, cfg.workers().num_loaders());
@@ -68,7 +68,12 @@ fn main() {
     // that have events left in their queue will panic when they try to send matching ones
     // to the loader through the load channel
     for handle in p_handles {
-        handle.join().unwrap();
+        if let Ok(res) = handle.join() {
+            match res {
+                Ok(s) => println!("{}", s),
+                Err(e) => println!("Error in processor: {}", e)
+            }
+        }
         println!("Joined processor");
     }
 


### PR DESCRIPTION
## Context: #15 
---
This is a pretty small one. Simply adds a `Stats` struct in the processing module and changes the return type of processor threads to `JoinHandle<Result<Stats>>` (from `JoinHandle<()>`