### PR TITLE
Rename settings module to config

### DIFF
--- a/config.tpl.yaml
+++ b/config.tpl.yaml
@@ -8,6 +8,6 @@ database:
     user: username # Default: postgres
     passwd: password # Either set this, or the INFOBSERVE_POSTGRES_PASSWD environmental variable
                      # (this value takes precedence). Default: infobserve
-    database: database # The database to connect. Default: postgres
+    db_name: database # The database to connect. Default: postgres
     host: host # Default: localhost
     port: port # Default: 5432


### PR DESCRIPTION
This commit renames the settings module to config (as well as the
`Settings` struct to `Config`). Additionally, changes a bit the way
settings are retrieved so instead of top-level methods with in-name
namespacing (e.g. `db_user()`), there are now top-level methods
returning the specific config object, which exposes its fields as
functions (e.g. `cfg.db().user()`)