### PR TITLE
Feature/add docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ README.md
 .gitignore
 **/.git
 Dockerfile
+scripts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM rust:1 as builder
 
 ENV YARA_VERSION=3.7.0
-COPY ./ processor-infobserve
 WORKDIR /processor-infobserve
+
 RUN apt update && \
     apt install wget automake libtool make gcc build-essential pkg-config llvm clang -y && \
     wget https://github.com/VirusTotal/yara/archive/v${YARA_VERSION}.tar.gz && \
@@ -12,20 +12,9 @@ RUN apt update && \
     ./configure && \
     make && \
     make install && \
-    cd .. && \
-    cargo build
+    cp /usr/local/lib/libyara.so /usr/lib/libyara.so.3
 
-RUN cp /usr/local/lib/libyara.so /usr/lib/libyara.so.3
+COPY ./ .
+RUN ls && cargo build
 
 ENTRYPOINT [ "./target/debug/processor-rs" ]
-
-# FROM ubuntu
-
-# RUN apt update && \
-#     apt install gcc libssl -y
-
-# COPY --from=builder /usr/local/bin/yara /usr/local/bin/yara
-# COPY --from=builder /usr/local/lib/libyara.so /usr/lib/libyara.so.3
-# COPY --from=builder /processor-infobserve/target/debug/processor-rs .
-
-# CMD ["./processor-rs"]

--- a/scripts/run_docker_container.sh
+++ b/scripts/run_docker_container.sh
@@ -1,0 +1,2 @@
+docker build . -t processor-rs
+docker run processor-rs


### PR DESCRIPTION
closes #23 

Vanilla image to avoid running in your system. Not using intermediate images for the build to improve the dockerfile size yet.
Adds a scripts directory to add utility scripts for the project.