### PR TITLE
Bump yara crate to v0.21.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 yaml-rust = "0.4.4"
 walkdir = "2"
-yara = "0.4.2"
+yara = { version = "0.21.0", features = ["vendored"] }
 log = "0.4"
 crossbeam-channel = "0.5.0"
 chrono = "0.4.19"
@@ -22,3 +22,6 @@ Inflector = "0.11.4"
 num_cpus = "1.13"
 thiserror = "1.0"
 clap = "3.0.0-beta.2"
+redis = "0.19"
+serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,9 @@
 FROM rust:1 as builder
 
-ENV YARA_VERSION=3.7.0
 WORKDIR /processor-infobserve
 
 RUN apt update && \
-    apt install wget automake libtool make gcc build-essential pkg-config llvm clang -y && \
-    wget https://github.com/VirusTotal/yara/archive/v${YARA_VERSION}.tar.gz && \
-    tar -zxf v${YARA_VERSION}.tar.gz && \
-    cd yara-${YARA_VERSION} && \
-    ./bootstrap.sh && \
-    ./configure && \
-    make && \
-    make install && \
-    cp /usr/local/lib/libyara.so /usr/lib/libyara.so.3
+    apt install wget automake libtool make gcc build-essential pkg-config llvm clang -y
 
 COPY ./ .
 RUN ls && cargo build

--- a/README.md
+++ b/README.md
@@ -5,64 +5,18 @@ Because we're lazy, there's no dockerfile yet
 Here's how to install locally:
 
 ### Install Yara
-For the processor to run, you'll need to have [Yara](https://github.com/VirusTotal/yara) installed
-
-Dependencies
-
-Ubuntu
-
-```
-# apt install automake libtool make gcc
-```
-
-
-
-Archlinux
-
-(you also need to install `autoconf`)
-
-```
-pacman -S automake autoconf libtool make gcc
-```
-
-Now actually install yara:
-```
-~/ $ wget https://github.com/VirusTotal/yara/archive/v3.7.0.tar.gz
-~/ $ tar zxf v3.7.0.tar.gz
-~/ $ cd yara-3.7.0
-~/yara-3.7.0 $ ./bootstrap.sh && ./configure && make && sudo make install
-```
-
-If you also want to make sure that Yara was installed correctly, go ahead and run
-```
-~/yara-3.7.0 $ make check
-```
-
+The processor depends on [Yara](https://github.com/VirusTotal/yara) to be installed locally. No manual installation is required
+as Yara is now included with the crate we use for exporting its bindings ([https://github.com/Hugal31/yara-rust/](yara-rust)).
+If a manual installation is preferred, the [installation steps can be found in Yara's documentation](https://yara.readthedocs.io/en/stable/gettingstarted.html)
 
 ### Cargo
-(Install rustup, cargo etc.)
+(First install rustup, cargo etc.)
 
 ```
 $ git clone https://gitub.com/Infobserve/processor-rs
 $ cd processor-rs
 $ cargo check # Check that everything is OK
 ```
-
-If the last command fails with something like the following: 
-```
-target/debug/processor-rs: error while loading shared libraries: libyara.so.3: cannot open shared object file: No such file or directory
-```
-
-
-
-(which is a problem with Yara linking), you might also need to run:
-```
-# ln -s /usr/local/lib/libyara.so /usr/lib/libyara.so.3
-```
-
-
-
-For the yara crate to compile, the `llvm-config` and `yara` executables must be available (they should be installed from the previous steps)
 
 That's it, you *should* be good to go.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,6 @@
 extern crate clap;
 
-use clap::{crate_authors, App, Arg};
+use clap::{App, Arg};
 
 pub struct Cli {
     config_path: String,
@@ -16,14 +16,12 @@ impl Cli {
     pub fn parse_args() -> Cli {
         let a = App::new("Infobserve Processor")
             .version("1.0")
-            .author(crate_authors!())
             .about("Invokes the Infobserve processor process")
             .arg(
                 Arg::new("config")
                     .short('c')
                     .long("config")
                     .value_name("CONFIG")
-                    .about("Sets a custom config file")
                     .default_value("config.yaml"),
             )
             .get_matches();

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
-use std::{fs, str, thread, sync::Arc, time, fmt};
-use log::{info, warn, error};
+use std::{str, thread, sync::Arc, time, fmt};
+use log::{info, error};
 
 use yara::{Compiler, Rules, Rule, YaraError};
 use crossbeam_channel::{Sender, Receiver};
@@ -103,8 +103,6 @@ fn process_forever(
                             error!("Failed to send processed event: {}", e);
                             stats.inc_failures();
                         }
-                    } else {
-                        warn!("Zero length match? {:?}", message);
                     }
                 }
                 Err(e) => println!("Whoops: {:?}", e)
@@ -153,12 +151,15 @@ impl Processor {
     /// Largely works the same as `Processor::from_dir`, but each file must
     /// be passed explicitly
     fn with_rule_files(filenames: Vec<String>) -> Result<Processor> {
-        let mut rules: Vec<String> = Vec::new();
+        let mut compiler = Compiler::new()?;
+
         for filename in filenames.into_iter() {
-            rules.push(fs::read_to_string(filename)?);
+            compiler = compiler.add_rules_file(&filename)?;
         }
 
-        Processor::with_rules(rules)
+        let engine = compiler.compile_rules()?;
+
+        Ok(Processor { engine })
     }
 
     /// Constructs a Processor object from a string representing a Yara rule
@@ -181,7 +182,7 @@ impl Processor {
         let mut compiler = Compiler::new()?;
 
         for rule in rules.into_iter() {
-            compiler.add_rules_str(&rule)?;
+            compiler = compiler.add_rules_str(&rule)?;
         }
 
         let engine = compiler.compile_rules()?;


### PR DESCRIPTION
The new version changes the crate's API. This commit includes the required changes to make it compilable too.

Additionally (and more importantly), the new version provides a `vendored` feature. When used, the Yara engine is also compiled during dependency resolution.
Ref: https://github.com/Hugal31/yara-rust/blob/master/yara-sys/README.md

Due to the above, the extra setup steps for installing yara have been removed, both from the Dockerfile, as well as the README