### PR TITLE
Add feeder

### DIFF
--- a/config.tpl.yaml
+++ b/config.tpl.yaml
@@ -14,3 +14,6 @@ database:
     db_name: database # The database to connect. Default: infobserve
     host: host # Default: localhost
     port: port # Default: 5432
+redis:
+    host: host # Default: localhost
+    port: port # Default: 6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3'
+
+services:
+  redis:
+    image: redis
+    container_name: redis-server
+    ports:
+      - "6379:6379"
+    networks:
+      - my_network
+
+  postgres:
+    image: postgres
+    container_name: postgres-server
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: infobserve
+      POSTGRES_DB: infobserve
+    ports:
+      - "5432:5432"
+    networks:
+      - my_network
+
+networks:
+  my_network:

--- a/src/entities/event.rs
+++ b/src/entities/event.rs
@@ -5,26 +5,35 @@ use chrono::{DateTime, Local};
 use r2d2_postgres::postgres::{Row, Transaction};
 use crate::database::Insert;
 use crate::entities::FlatMatch;
+use serde_json::Value;
 
+use crate::errors::DeserializationError;
+
+const DATETIME_FMT: &str = "%Y/%m/%d-%H:%M:%S";
+
+/// Responsible for the deserialization as well as DB insertion of
+/// events. Contains the following fields:
+/// 
+/// 
+/// id - A unique identifier for this event. Could be of different format based on the source
+/// url - The url from which this file was retrieved
+/// size - The size of the file (in bytes)
+/// source - The source in which the paste was found
+/// raw_content - The entire content of the file as retrieved from the source
+/// filename - The name of the file as retrieved from the source
+/// creator - The username of the creator
+/// created_at - Time at which the paste was created
+/// discovered_at - Time at which the paste was scraped
 #[derive(Debug)]
 pub struct Event {
-    /// A unique identifier for this event. Could be of different format based on the source
     id: Option<i32>,
-    /// The url from which this file was retrieved
     url: String,
-    /// The size of the file (in bytes)
-    size: i64,
-    /// The source in which the paste was found
+    size: usize,
     source: String,
-    /// The entire content of the file as retrieved from the source
     raw_content: String,
-    /// The name of the file as retrieved from the source
     filename: String,
-    /// The username of the creator
     creator: String,
-    /// Time at which the paste was created
     created_at: DateTime<Local>,
-    /// Time at which the paste was discovered
     discovered_at: DateTime<Local>
 }
 
@@ -32,6 +41,15 @@ pub struct Event {
 pub struct ProcessedEvent(pub Event, pub Vec<FlatMatch>);
 
 impl Insert for Event {
+    /// Insert the event into the DB
+    /// 
+    /// # Arguments
+    /// 
+    /// * conn - A currently open (uncommitted) DB transaction
+    /// 
+    /// # Returns
+    /// 
+    /// An empty Result
     fn insert(&mut self, conn: &mut Transaction) -> Result<()> {
         let stmt = "
         INSERT INTO events
@@ -57,7 +75,7 @@ impl Insert for Event {
             &[
                 &self.source,
                 &self.url,
-                &self.size,
+                &(self.size as i64),
                 &self.raw_content,
                 &self.filename,
                 &self.creator,
@@ -72,28 +90,53 @@ impl Insert for Event {
 }
 
 impl Event {
+    pub fn from_json_str(json_str: &str) -> Result<Self> {
+        let json: Value = serde_json::from_str(json_str)?;
+
+        let url = Self::get_str(&json, "url")?;
+        let size = Self::get_i64(&json, "size")? as usize;
+        let source = Self::get_str(&json, "source")?;
+        let raw_content = Self::get_str(&json, "raw_content")?;
+        let filename = Self::get_str(&json, "filename")?;
+        let creator = Self::get_str(&json, "creator")?;
+        let created_at: DateTime<Local> = 
+            match Self::get_str(&json, "created_at") {
+                Ok(c) => DateTime::parse_from_str(&c, DATETIME_FMT)?.into(),
+                Err(e) => return Err(e)
+                
+            };
+        let discovered_at: DateTime<Local> =
+            match Self::get_str(&json, "discovered_at") {
+                Ok(c) => DateTime::parse_from_str(&c, DATETIME_FMT)?.into(),
+                Err(e) => return Err(e)
+            };
+
+        Ok(Self::new(&url, size, &source, &raw_content, &filename, &creator, created_at, discovered_at))
+    }
+
     pub fn new(
         url: &str,
-        size: i64,
+        size: usize,
         source: &str,
         raw_content: &str,
         filename: &str,
         creator: &str,
+        created_at: DateTime<Local>,
         discovered_at: DateTime<Local>
     ) -> Self {
-        Self::create(None, url, size, source, raw_content, filename, creator, None, discovered_at)
+        Self::create( None, url, size, source, raw_content, filename, creator, created_at, discovered_at)
     }
 
     pub fn from_row(row: Row) -> Self {
         Self::create(
             Some(row.get("id")),
             row.get("url"),
-            row.get("size"),
+            row.get::<&str, i64>("size") as usize,
             row.get("source"),
             row.get("raw_content"),
             row.get("filename"),
             row.get("creator"),
-            Some(row.get("created_at")),
+            row.get("created_at"),
             row.get("discovered_at")
         )
     }
@@ -106,7 +149,7 @@ impl Event {
         &self.url
     }
 
-    pub fn size(&self) -> i64 {
+    pub fn size(&self) -> usize {
         self.size
     }
 
@@ -138,19 +181,14 @@ impl Event {
     fn create(
         id: Option<i32>,
         url: &str,
-        size: i64,
+        size: usize,
         source: &str,
         raw_content: &str,
         filename: &str,
         creator: &str,
-        created_at: Option<DateTime<Local>>,
+        created_at: DateTime<Local>,
         discovered_at: DateTime<Local>
     ) -> Self {
-        let created_at = match created_at {
-            Some(ca) => ca,
-            None => Local::now()
-        };
-
         Self {
             id,
             url: url.to_owned(),
@@ -162,5 +200,20 @@ impl Event {
             created_at,
             discovered_at
         }
+    }
+
+    fn get_str(json: &Value, field_name: &str) -> Result<String> {
+        match json[field_name].as_str() {
+            Some(u) => Ok(u.to_owned()),
+            None => return Err(DeserializationError::NoValueError(field_name.to_string()).into())
+        }
+    }
+
+    fn get_i64(json: &Value, field_name: &str) -> Result<i64> {
+        match json[field_name].as_i64() {
+            Some(u) => Ok(u.to_owned()),
+            None => return Err(DeserializationError::NoValueError(field_name.to_string()).into())
+        }
+
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,3 +9,9 @@ pub enum ConfigurationError {
     #[error("Number of workers cannot be negative")]
     NegativeWorkersError
 }
+
+#[derive(Error, Debug)]
+pub enum DeserializationError {
+    #[error("Empty '{0}' value when deserializing event")]
+    NoValueError(String)
+}

--- a/src/feeder.rs
+++ b/src/feeder.rs
@@ -1,0 +1,123 @@
+use log::{info, error};
+use std::thread::{self, JoinHandle};
+
+use crossbeam_channel::Sender;
+use redis::{Client, Commands, Connection};
+use anyhow::Result;
+
+use crate::entities::Event;
+
+/// Spawns `num_feeders` threads. Each thread listens for events through redis. Whenever an event is fetched,
+/// a message is written in the sender end of a crossbeam channel (normally, a processing thread is listening
+/// on the receiving end of that)
+/// 
+/// # Arguments
+/// 
+/// * sendr - The write-end of a crossbeam channel. All events fetched from redis will be written there.
+///           If a quit message is received instead of an event, then this sender is dropped, effectively
+///           unblocking all threads listening to it.
+/// * host - Redis host
+/// * port - Redis port
+/// * num_feeders - The amount of feeder threads to spawn
+/// 
+/// # Return
+/// A vector of join handles that can be used to join the threads. Threads will exit their loops only
+/// if a quit command is received from Redis.
+/// 
+/// # Example
+/// ```
+/// use feeder::start_feeders;
+/// 
+/// let (proc_sendr, proc_receiver) = crossbeam_channel::unbounded();
+///
+/// let handles: Vec<JoinHandle<()>> = start_feeders(&proc_sendr, "localhost", 6379, 2);
+///
+/// assert_eq!(handles.len(), 2);
+/// // for msg in proc_receiver {
+/// //     println!("Received event!");
+/// // }
+///
+/// for handle in handles {
+///     handle.join().unwrap();
+/// }
+/// ```
+pub fn start_feeders(sendr: &Sender<Event>, host: &str, port: u16, num_feeders: i32) -> Vec<JoinHandle<()>> {
+    let mut threads = Vec::with_capacity(num_feeders as usize);
+
+    for _ in 0..num_feeders {
+        let mut feeder = Feeder::connect(&host, port).expect(&format!("redis connection @redis://{}:{}", host, port));
+        let sendr_copy = Sender::clone(sendr);
+        threads.push(
+            thread::spawn(move || {
+                if let Err(e) = feeder.listen(&sendr_copy) {
+                    error!("Feeder encountered an error!: {}", e);
+                    return;
+                }
+            })
+        );
+    }
+
+    threads
+}
+
+struct Feeder {
+    client: Client
+}
+
+impl Feeder {
+    /// Opens a connection to a Redis server and retains a handle for it
+    fn connect(host: &str, port: u16) -> Result<Self> {
+        let client = Client::open(format!("redis://{}:{}/", host, port))?;
+
+        Ok(Self { client })
+    }
+
+    /// Continuously listens for events from Redis. Whenever an event is encountered, it is written
+    /// in `sendr`
+    fn listen(&mut self, sendr: &Sender<Event>) -> Result<()> {
+        let mut conn = self.client.get_connection()?;
+
+        loop {
+            let msg = match self.pop_msg(&mut conn) {
+                Ok(m) => m,
+                Err(e) => {
+                    error!("Could not pop event from redis queue: {}", e);
+                    continue;
+                }
+            };
+            
+            info!("New message in {}", msg.name);
+
+            let payload = msg.payload;
+
+            if &payload == "QUIT" {
+                break;
+            }
+
+            match Event::from_json_str(&payload) {
+                Ok(e) => {
+                    if let Err(e) = sendr.send(e) {
+                        error!("Could not send event to processor: {}", e);
+                    }
+                },
+                Err(e) => error!("Could not deserialize message from redis: msg: {}, error: {}", payload, e)
+            }
+        }
+
+        Ok(())
+    }
+
+    fn pop_msg(&self, conn: &mut Connection) -> Result<Message> {
+        let msg: Vec<String> = conn.blpop("events", 0)?;
+
+        Ok(Message {
+            name: msg[0].to_owned(),
+            payload: msg[1].to_owned()
+        })
+    }
+}
+
+struct Message {
+    name: String,
+    payload: String
+}


### PR DESCRIPTION
# What

This PR adds feeder threads. These spawn at the startup of the process, along processing and DB loading threads. The number of these threads is configurable through the `workers:num_feeders` key in `config.yaml` (default 1)

# How

Support for connections to Redis has been implemented. The feeder threads, upon spawning, immediately block on a Redis `BLPOP` command, waiting for events. When an event is fetched from Redis, it is deserialized into an `Event` object and written in a crossbeam channel for processing.

# How to test

Start the required services (Redis & PostgreSQL), as well as the processor

```bash
docker-compose up -d
cargo run # This should also install yara after #29. If not, ping
```

You can write some events to redis by hand (with `redis-cli` or whatever) or use `publish.py` which reads events from `fixtures/events.json` and writes them to Redis (under `events`)

Using an SQL client, check the `ascii_matches` table. If you used `publish.py` with the default `events.json` file, there should be exactly 3 rows (`events.json` contains 4 events but only 3 match with our rules)